### PR TITLE
Rollback default branch name to master

### DIFF
--- a/utils/installer/install.sh
+++ b/utils/installer/install.sh
@@ -2,7 +2,7 @@
 set -eo pipefail
 
 #Set branch to master unless specified by the user
-declare LV_BRANCH="${LV_BRANCH:-"rolling"}"
+declare LV_BRANCH="${LV_BRANCH:-"master"}"
 declare -r LV_REMOTE="${LV_REMOTE:-lunarvim/lunarvim.git}"
 declare -r INSTALL_PREFIX="${INSTALL_PREFIX:-"$HOME/.local"}"
 


### PR DESCRIPTION
A few days ago the default installation branch was changed to `rolling` however everywhere in the documentation its still stated as `master`. Also I found no remarks about why it was changed, so I think it might me unwanted.

So I reverted it to `mater`

